### PR TITLE
0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ _Breaking update. Please backup and remove your .pset and .ptn data files from p
 
 * It's now possible to set a clock division or multiplication for global scale, enabling slower or faster scale progressions and progressions that apply using sequences of less than 64 steps.
 * Midi clock sync logic has been improved
-* Clock logic has been improved
+* Clock logic has been entirely rewritten and is much more stable
 * Various clock and sequencer bug fixes
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 _Breaking update. Please backup and remove your .pset and .ptn data files from previous versions._
 
 * It's now possible to set a clock division or multiplication for global scale, enabling slower or faster scale progressions and progressions that apply using sequences of less than 64 steps.
+* Midi clock sync logic has been improved
+* Clock logic has been improved
+* Various clock and sequencer bug fixes
 
 
 # 0.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.1
+
+_Breaking update. Please backup and remove your .pset and .ptn data files from previous versions._
+
+* It's now possible to set a clock division or multiplication for global scale, enabling slower or faster scale progressions and progressions that apply using sequences of less than 64 steps.
+
+
 # 0.3
 
 _Breaking update. Please backup and remove your .pset and .ptn data files from previous versions._

--- a/lib/clock_controller.lua
+++ b/lib/clock_controller.lua
@@ -136,6 +136,11 @@ function clock_controller.init()
   
         if channel_number == 17 then
           step_handler.process_global_step_scale_trig_lock(current_step)
+
+          if sinfonion ~= true then
+            step_handler.sinfonian_sync(current_step)
+          end
+        
         end
 
         if channel_number ~= 17 then
@@ -187,10 +192,6 @@ function clock_controller.init()
       step_handler.process_lengths()
       if first_run ~= true then
         step_handler.process_song_sequencer_patterns(program.get().current_step)
-      end
-    
-      if sinfonion ~= true then
-        step_handler.sinfonian_sync(program.get().current_step)
       end
     
       program.get().current_step = program.get().current_step + 1

--- a/lib/clock_controller.lua
+++ b/lib/clock_controller.lua
@@ -178,7 +178,7 @@ function clock_controller.init()
       end,
       division = 1/(div*4),
       swing = swing,
-      delay = 0.85,
+      delay = 0.99,
       enabled = true
     }
 

--- a/lib/controls/Sequencer.lua
+++ b/lib/controls/Sequencer.lua
@@ -97,7 +97,7 @@ function Sequencer:draw(channel, draw_func)
     for x = 1, 16 do    
       local grid_count = fn.calc_grid_count(x, y)
 
-      local in_step_length = start_step <= fn.calc_grid_count(x, y) and end_step >= fn.calc_grid_count(x, y)
+      local in_step_length = start_step <= grid_count and end_step >= grid_count
 
       if (self.unsaved_grid[grid_count]) then
         draw_func(x, y, 15 - self.bclock.bright_mod)
@@ -125,7 +125,7 @@ function Sequencer:draw(channel, draw_func)
         if (length > 1 and in_step_length) then
           for lx = grid_count + 1, grid_count + length - 1 do
             if (trigs[lx] < 1 and lx < 65) then
-              draw_func((lx % 16), 4 + ((lx - 1) // 16 ), 5)
+              draw_func((lx - 1) % 16 + 1, 4 + ((lx - 1) // 16 ), 5)
             else
               break
             end

--- a/lib/controls/Sequencer.lua
+++ b/lib/controls/Sequencer.lua
@@ -36,19 +36,6 @@ function Sequencer:new(y, mode)
   return self
 end
 
-local function transform_current_step(current_step)
-  local mod_step = current_step - 1
-  local channel = program.get_selected_channel()
-
-  local start_step = fn.calc_grid_count(channel.start_trig[1], channel.start_trig[2])
-  local end_step = fn.calc_grid_count(channel.end_trig[1], channel.end_trig[2])
-
-  if mod_step == start_step - 1 then
-    mod_step = end_step
-  end
-
-  return mod_step
-end
 
 function Sequencer:draw(channel, draw_func)
 
@@ -81,7 +68,7 @@ function Sequencer:draw(channel, draw_func)
 
   local current_step = program.get().current_step
 
-  current_step = transform_current_step(program.get_current_step_for_channel(channel.number))
+  current_step = program.get_current_step_for_channel(channel.number)
 
   for y = self.y, self.y + 3 do
     for x = 1, 16 do
@@ -105,6 +92,7 @@ function Sequencer:draw(channel, draw_func)
   end
 
 
+
   for y = self.y, self.y + 3 do
     for x = 1, 16 do    
       local grid_count = fn.calc_grid_count(x, y)
@@ -118,19 +106,11 @@ function Sequencer:draw(channel, draw_func)
       if (trigs[grid_count] > 0) then
         if (self.mode == "channel") then
           if (in_step_length) then
-              if fn.calc_grid_count(x, y) == end_step and current_step == start_step then 
-                if program.step_has_trig_lock(channel, grid_count) then
-                  draw_func(end_x, end_y, 10 - self.bclock.bright_mod)
-                else
-                  draw_func(end_x, end_y, 10)
-                end
-              else
-                if program.step_has_trig_lock(channel, grid_count) then
-                  draw_func(x, y, 15 - self.bclock.bright_mod)
-                else
-                  draw_func(x, y, 15) 
-                end
-              end
+            if program.step_has_trig_lock(channel, grid_count) then
+              draw_func(x, y, 15 - self.bclock.bright_mod)
+            else
+              draw_func(x, y, 15) 
+            end
           end
         else
           draw_func(x, y, 15) 
@@ -154,7 +134,9 @@ function Sequencer:draw(channel, draw_func)
 
       end
 
+      
       if current_step == grid_count and clock_controller.is_playing() then
+
         if (self.mode == "channel") then
           if fn.calc_grid_count(x, y) >= start_step then 
 

--- a/lib/controls/Sequencer.lua
+++ b/lib/controls/Sequencer.lua
@@ -130,7 +130,10 @@ function Sequencer:draw(channel, draw_func)
             end
 
             if (trigs[lx] < 1 and lx < 65) then
-              draw_func((lx - 1) % 16 + 1, 4 + ((lx - 1) // 16 ), 5)
+              local length_grid_count = fn.calc_grid_count((lx - 1) % 16 + 1, 4 + ((lx - 1) // 16))
+              if start_step <= length_grid_count and end_step >= length_grid_count then
+                draw_func((lx - 1) % 16 + 1, 4 + ((lx - 1) // 16 ), 5)
+              end
             else
               break
             end

--- a/lib/controls/Sequencer.lua
+++ b/lib/controls/Sequencer.lua
@@ -81,9 +81,7 @@ function Sequencer:draw(channel, draw_func)
 
   local current_step = program.get().current_step
 
-  if channel.number ~= 17 then
-    current_step = transform_current_step(program.get_current_step_for_channel(channel.number))
-  end
+  current_step = transform_current_step(program.get_current_step_for_channel(channel.number))
 
   for y = self.y, self.y + 3 do
     for x = 1, 16 do

--- a/lib/controls/Sequencer.lua
+++ b/lib/controls/Sequencer.lua
@@ -124,6 +124,11 @@ function Sequencer:draw(channel, draw_func)
         
         if (length > 1 and in_step_length) then
           for lx = grid_count + 1, grid_count + length - 1 do
+
+            if lx > 64 then
+              lx = lx - 64
+            end
+
             if (trigs[lx] < 1 and lx < 65) then
               draw_func((lx - 1) % 16 + 1, 4 + ((lx - 1) // 16 ), 5)
             else
@@ -182,6 +187,8 @@ function Sequencer:dual_press(x, y, x2, y2)
       if (program.get_selected_pattern().trig_values[fn.calc_grid_count(x, y)] == 1) then
         if (fn.calc_grid_count(x2, y2) - fn.calc_grid_count(x, y) > 0) then
           program.get_selected_pattern().lengths[fn.calc_grid_count(x, y)] = (fn.calc_grid_count(x2, y2) + 1) - fn.calc_grid_count(x, y)
+        else
+          program.get_selected_pattern().lengths[fn.calc_grid_count(x, y)] = (64 - fn.calc_grid_count(x, y)) + ((fn.calc_grid_count(x2, y2)) + 1)
         end
       end
     end

--- a/lib/device_map.lua
+++ b/lib/device_map.lua
@@ -6106,6 +6106,7 @@ local stock_device_map = {
 
 
 local stock_params = {
+  get_none_param(),
   {
     ["id"] = "fixed_note",
     ["name"] = "Fixed Note",
@@ -6194,9 +6195,6 @@ local function merge_devices()
     -- Handle insertion or removal based on 'hide' attribute
     if not cd.hide then
       if not sd then
-        if cd["params"][1].id ~= "none" then
-          table.insert(cd.params, 1, get_none_param())
-        end
         table.insert(stock_device_map, cd)
         -- Update the lookup map
         stock_map_by_id[cd.id] = cd

--- a/lib/functions.lua
+++ b/lib/functions.lua
@@ -220,9 +220,9 @@ function fn.find_index_in_table_by_id(table, object)
   return nil
 end
 
-function fn.find_index_in_table_by_value(table, object)
+function fn.find_index_in_table_by_value(table, value)
   for i, o in ipairs(table) do
-    if o.value == object.value then
+    if o.value == value then
       return i
     end
   end
@@ -265,6 +265,16 @@ function fn.remove_table_from_table(t, object)
           return
       end
   end
+end
+
+function fn.filter_by_type(input_table, filter_type)
+  local filtered = {}
+  for _, item in ipairs(input_table) do
+      if item.type == filter_type then
+          table.insert(filtered, item)
+      end
+  end
+  return filtered
 end
 
 function fn.scale(num, old_min, old_max, new_min, new_max)

--- a/lib/grid_controller.lua
+++ b/lib/grid_controller.lua
@@ -36,6 +36,7 @@ local page_names = {
 }
 
 local pressed_keys = {}
+local dual_in_progress = false
 
 g = grid.connect()
 
@@ -56,9 +57,16 @@ function g.key(x, y, z)
       if grid_controller.long_press_active[x][y] == true then
         grid_controller.long_press_active[x][y] = false
       elseif held_button ~= nil then
+        if grid_controller.counter[held_button[1]][held_button[2]] then
+          clock.cancel(grid_controller.counter[held_button[1]][held_button[2]])
+        end
         grid_controller.dual_press(held_button[1], held_button[2], x, y)
+        dual_in_progress = true
       else
-        grid_controller.short_press(x,y) -- and execute a short press instead.
+        if dual_in_progress ~= true then
+          grid_controller.short_press(x,y) -- and execute a short press instead.
+        end
+        dual_in_progress = false
       end
     end
     grid_controller.post_press(x,y)

--- a/lib/midi_controller.lua
+++ b/lib/midi_controller.lua
@@ -85,7 +85,6 @@ function midi_controller.nrpn(nrpn_msb, nrpn_lsb, value, channel, device)
 end
 
 function midi_controller.start()
-  clock.sync(0.01)
   for id = 1, #midi.vports do
     if midi_devices[id].device ~= nil then
       midi_devices[id]:start()

--- a/lib/midi_controller.lua
+++ b/lib/midi_controller.lua
@@ -92,26 +92,10 @@ function midi_controller.start()
   end
 end
 
-function midi_controller.continue()
-  for id = 1, #midi.vports do
-    if midi_devices[id].device ~= nil then
-      midi_devices[id]:continue()
-    end
-  end
-end
-
 function midi_controller.stop()
   for id = 1, #midi.vports do
     if midi_devices[id].device ~= nil then
       midi_devices[id]:stop()
-    end
-  end
-end
-
-function midi_controller.clock_send()
-  for id = 1, #midi.vports do
-    if midi_devices[id].device ~= nil then
-      midi_devices[id]:clock()
     end
   end
 end

--- a/lib/midi_controller.lua
+++ b/lib/midi_controller.lua
@@ -85,6 +85,7 @@ function midi_controller.nrpn(nrpn_msb, nrpn_lsb, value, channel, device)
 end
 
 function midi_controller.start()
+  clock.sync(0.01)
   for id = 1, #midi.vports do
     if midi_devices[id].device ~= nil then
       midi_devices[id]:start()

--- a/lib/pages/channel_edit_page_controller.lua
+++ b/lib/pages/channel_edit_page_controller.lua
@@ -56,7 +56,6 @@ function channel_edit_page_controller.init()
 
   channel_scale_fader:set_pre_func(function(x, y, length) 
     for i = x, length + x - 1 do
-      -- print(program.get_selected_channel().step_scale_number)
       if i == program.get_selected_channel().step_scale_number then
         grid_abstraction.led(i, y, 4)
       end

--- a/lib/pages/channel_edit_page_controller.lua
+++ b/lib/pages/channel_edit_page_controller.lua
@@ -56,6 +56,7 @@ function channel_edit_page_controller.init()
 
   channel_scale_fader:set_pre_func(function(x, y, length) 
     for i = x, length + x - 1 do
+      -- print(program.get_selected_channel().step_scale_number)
       if i == program.get_selected_channel().step_scale_number then
         grid_abstraction.led(i, y, 4)
       end

--- a/lib/pages/channel_edit_page_controller.lua
+++ b/lib/pages/channel_edit_page_controller.lua
@@ -296,6 +296,7 @@ function channel_edit_page_controller.register_press_handlers()
         else
           channel_scale_fader:set_value(0)
         end
+        channel_edit_page_ui_controller.refresh()
       end
     end
   )

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -247,6 +247,9 @@ function channel_edit_page_ui_controller.update_swing()
   local swing = clock_swing_value_selector:get_value()
 
   channel.swing = swing
+
+  clock_controller.set_channel_swing(channel.number, swing)
+
 end
 
 function channel_edit_page_ui_controller.update_clock_mods()
@@ -255,6 +258,8 @@ function channel_edit_page_ui_controller.update_clock_mods()
   print("updating clock mods")
 
   channel.clock_mods = clock_mods
+
+  clock_controller.set_channel_division(channel.number, clock_controller.calculate_divisor(clock_mods))
 end
 
 function channel_edit_page_ui_controller.update_default_params()

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -255,7 +255,6 @@ end
 function channel_edit_page_ui_controller.update_clock_mods()
   local channel = program.get_selected_channel()
   local clock_mods = clock_mod_list_selector:get_selected()
-  print("updating clock mods")
 
   channel.clock_mods = clock_mods
 
@@ -952,7 +951,6 @@ function channel_edit_page_ui_controller.refresh_channel_config()
   midi_device_vertical_scroll_selector:set_selected_item(program.get().devices[channel.number].midi_device)
   device_map_vertical_scroll_selector:set_selected_item(fn.get_index_by_id(device_map_vertical_scroll_selector:get_items(), program.get().devices[channel.number].device_map))
 
-  print(fn.get_index_by_id(param_select_vertical_scroll_selector:get_items(), channel.trig_lock_params[dials:get_selected_index()].id) or 1)
   param_select_vertical_scroll_selector:set_selected_item(fn.get_index_by_id(param_select_vertical_scroll_selector:get_items(), channel.trig_lock_params[dials:get_selected_index()].id) or 1)
 
   device_map_vertical_scroll_selector:select()

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -22,7 +22,7 @@ local romans_vertical_scroll_selector = VerticalScrollSelector:new(105, 25, "Rom
 local notes_vertical_scroll_selector = VerticalScrollSelector:new(10, 25, "Notes", quantiser.get_notes())
 
 local clock_mod_list_selector = ListSelector:new(10, 25, "Clock Mod", {})
-local clock_swing_value_selector = ValueSelector:new(70, 25, "Swing", 0, 50)
+local clock_swing_value_selector = ValueSelector:new(70, 25, "Swing", 0, 100)
 
 local midi_device_vertical_scroll_selector = VerticalScrollSelector:new(90, 25, "Midi Device", {})
 local midi_channel_vertical_scroll_selector = VerticalScrollSelector:new(65, 25, "Midi Channel", {{name = "CC1", value = 1}, {name = "CC2", value = 2}, {name = "CC3", value = 3}, {name = "CC4", value = 4}, {name = "CC5", value = 5}, {name = "CC6", value = 6}, {name = "CC7", value = 7}, {name = "CC8", value = 8}, {name = "CC9", value = 9}, {name = "CC10", value = 10}, {name = "CC11", value = 11}, {name = "CC12", value = 12}, {name = "CC13", value = 13}, {name = "CC14", value = 14}, {name = "CC15", value = 15}, {name = "CC16", value = 16}})
@@ -181,7 +181,7 @@ function channel_edit_page_ui_controller.init()
   dials:set_selected_item(1)
   clock_mod_list_selector:set_selected_value(13)
   clock_mod_list_selector:select()
-  clock_swing_value_selector:set_value(0)
+  clock_swing_value_selector:set_value(50)
 
   channel_edit_page_ui_controller.refresh_clock_mods()
 end

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -252,6 +252,7 @@ end
 function channel_edit_page_ui_controller.update_clock_mods()
   local channel = program.get_selected_channel()
   local clock_mods = clock_mod_list_selector:get_selected()
+  print("updating clock mods")
 
   channel.clock_mods = clock_mods
 end

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -343,7 +343,9 @@ function channel_edit_page_ui_controller.enc(n, d)
     for i=1, math.abs(d) do
       if d > 0 then
         if pages:get_selected_page() == page_to_index["Quantizer"] then
-
+          if program.get_selected_channel().default_scale == 0 or program.get().default_scale == 0 then
+            return
+          end
           if quantizer_vertical_scroll_selector:is_selected() then
             quantizer_vertical_scroll_selector:scroll_down()
             channel_edit_page_ui_controller.refresh_romans() 
@@ -466,6 +468,9 @@ function channel_edit_page_ui_controller.enc(n, d)
 
       else
         if pages:get_selected_page() == page_to_index["Quantizer"] then
+          if program.get_selected_channel().default_scale == 0 or program.get().default_scale == 0 then
+            return
+          end
           if quantizer_vertical_scroll_selector:is_selected() then
             quantizer_vertical_scroll_selector:scroll_up()
             channel_edit_page_ui_controller.refresh_romans() 
@@ -593,6 +598,9 @@ function channel_edit_page_ui_controller.enc(n, d)
       if d > 0 then
 
         if pages:get_selected_page() == page_to_index["Quantizer"] then
+          if program.get_selected_channel().default_scale == 0 or program.get().default_scale == 0 then
+            return
+          end
           if quantizer_vertical_scroll_selector:is_selected() then
             quantizer_vertical_scroll_selector:deselect()
             romans_vertical_scroll_selector:select()
@@ -651,6 +659,9 @@ function channel_edit_page_ui_controller.enc(n, d)
         end
       else
         if pages:get_selected_page() == page_to_index["Quantizer"] then
+          if program.get_selected_channel().default_scale == 0 or program.get().default_scale == 0 then
+            return
+          end
           if quantizer_vertical_scroll_selector:is_selected() then
             quantizer_vertical_scroll_selector:deselect()
             notes_vertical_scroll_selector:select()
@@ -798,6 +809,11 @@ function channel_edit_page_ui_controller.refresh_clock_mods()
   end
 
   clock_mod_list_selector:set_selected_value(i)
+
+  if channel.number == 17 then
+    clock_mod_list_selector:select()
+    clock_swing_value_selector:deselect()
+  end
 
 end
 

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -756,6 +756,7 @@ function channel_edit_page_ui_controller.key(n, z)
           channel_edit_page_ui_controller.refresh_device_selector()
           channel_edit_page_ui_controller.refresh_param_list()
         end
+        channel_edit_page_ui_controller.refresh_channel_config()
         trig_lock_page:toggle_sub_page()
       else
         k2_held = true
@@ -950,6 +951,8 @@ function channel_edit_page_ui_controller.refresh_channel_config()
   midi_channel_vertical_scroll_selector:set_selected_item(program.get().devices[channel.number].midi_channel)
   midi_device_vertical_scroll_selector:set_selected_item(program.get().devices[channel.number].midi_device)
   device_map_vertical_scroll_selector:set_selected_item(fn.get_index_by_id(device_map_vertical_scroll_selector:get_items(), program.get().devices[channel.number].device_map))
+
+  print(fn.get_index_by_id(param_select_vertical_scroll_selector:get_items(), channel.trig_lock_params[dials:get_selected_index()].id) or 1)
   param_select_vertical_scroll_selector:set_selected_item(fn.get_index_by_id(param_select_vertical_scroll_selector:get_items(), channel.trig_lock_params[dials:get_selected_index()].id) or 1)
 
   device_map_vertical_scroll_selector:select()

--- a/lib/pages/channel_edit_page_ui_controller.lua
+++ b/lib/pages/channel_edit_page_ui_controller.lua
@@ -84,11 +84,10 @@ end
 
 local clock_mods_page = Page:new("Clocks and Swing", function ()
   if program.get().selected_channel ~= 17 then
-    clock_mod_list_selector:draw()
     clock_swing_value_selector:draw()
-  else
-    print_quant_message_to_screen()
   end
+
+  clock_mod_list_selector:draw()
 end)
 
 local channel_edit_page = Page:new("Config", function ()
@@ -184,7 +183,7 @@ function channel_edit_page_ui_controller.init()
   clock_mod_list_selector:select()
   clock_swing_value_selector:set_value(0)
 
-  channel_edit_page_ui_controller.refresh()
+  channel_edit_page_ui_controller.refresh_clock_mods()
 end
 
 function channel_edit_page_ui_controller.register_ui_draw_handlers() 
@@ -351,9 +350,7 @@ function channel_edit_page_ui_controller.enc(n, d)
           end
           channel_edit_page_ui_controller.update_scale()
         elseif pages:get_selected_page() == page_to_index["Clock Mods"] then
-          if program.get().selected_channel == 17 then
-            return
-          end
+
           if clock_mod_list_selector:is_selected() then
             clock_mod_list_selector:decrement()
             save_confirm.set_save(function() 
@@ -362,6 +359,9 @@ function channel_edit_page_ui_controller.enc(n, d)
             save_confirm.set_cancel(function()
               channel_edit_page_ui_controller.refresh_clock_mods()
             end)
+          end
+          if program.get().selected_channel == 17 then
+            return
           end
           if clock_swing_value_selector:is_selected() then
             clock_swing_value_selector:increment()
@@ -472,9 +472,6 @@ function channel_edit_page_ui_controller.enc(n, d)
           end
           channel_edit_page_ui_controller.update_scale()
         elseif pages:get_selected_page() == page_to_index["Clock Mods"] then
-          if program.get().selected_channel == 17 then
-            return
-          end
           if clock_mod_list_selector:is_selected() then
             clock_mod_list_selector:increment()
             save_confirm.set_save(function() 
@@ -483,6 +480,9 @@ function channel_edit_page_ui_controller.enc(n, d)
             save_confirm.set_cancel(function()
               channel_edit_page_ui_controller.refresh_clock_mods()
             end)
+          end
+          if program.get().selected_channel == 17 then
+            return
           end
           if clock_swing_value_selector:is_selected() then
             clock_swing_value_selector:decrement()
@@ -782,7 +782,15 @@ end
 function channel_edit_page_ui_controller.refresh_clock_mods()
   local channel = program.get_selected_channel()
   local clock_mods = channel.clock_mods
-  local i = fn.find_index_in_table_by_value(clock_controller.get_clock_divisions(), channel.clock_mods)
+
+  local divisions = fn.filter_by_type(clock_controller.get_clock_divisions(), clock_mods.type)
+
+  local i = fn.find_index_in_table_by_value(divisions, clock_mods.value)
+
+  if clock_mods.type == "clock_division" then
+    i = i + 12
+  end
+
   clock_mod_list_selector:set_selected_value(i)
 
 end

--- a/lib/program.lua
+++ b/lib/program.lua
@@ -129,7 +129,6 @@ function program.init()
     root_note = root_note,
     chord = 1,
     default_scale = 0,
-    chord = 1,
     current_step = 1,
     current_channel_step = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
     sequencer_patterns = {},

--- a/lib/program.lua
+++ b/lib/program.lua
@@ -42,7 +42,7 @@ local function initialise_default_channels()
       clock_mods = {name = "/1", value = 1, type = "clock_division"},
       current_step = 1,
       mute = false,
-      swing = 0
+      swing = 50
     }
   end
   

--- a/lib/program.lua
+++ b/lib/program.lua
@@ -131,7 +131,7 @@ function program.init()
     default_scale = 0,
     chord = 1,
     current_step = 1,
-    current_channel_step = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
+    current_channel_step = {1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1},
     sequencer_patterns = {},
     devices = {
       {midi_channel = 1, midi_device = 1, device_map = "none"},
@@ -186,7 +186,7 @@ function program.set_sequencer_pattern(p, pattern)
   local sequencer_pattern = fn.deep_copy(program.get_sequencer_pattern(p))
 
   if params:get("reset_on_end_of_pattern") == 1 then
-    for i = 1, 16 do
+    for i = 1, 17 do
       program.set_current_step_for_channel(i, 1)
     end
   end

--- a/lib/program.lua
+++ b/lib/program.lua
@@ -201,12 +201,20 @@ function program.set_current_step_for_channel(c, s)
   program_store.current_channel_step[c] = s
 end
 
+function program.set_global_step_scale_number(step_scale_number)
+
+  for _, sequencer_pattern in pairs(program_store.sequencer_patterns) do
+    sequencer_pattern.channels[17].step_scale_number = step_scale_number
+  end
+
+end
+
 function program.get()
   return program_store
 end
 
 function program.get_selected_channel()
-  return program.get_sequencer_pattern(program_store.selected_sequencer_pattern).channels[program_store.selected_channel]
+  return program.get_sequencer_pattern(program.get().selected_sequencer_pattern).channels[program.get().selected_channel]
 end
 
 function program.get_selected_pattern()
@@ -214,7 +222,7 @@ function program.get_selected_pattern()
 end
 
 function program.get_channel(x)
-  return program.get_sequencer_pattern(program_store.selected_sequencer_pattern).channels[x]
+  return program.get_sequencer_pattern(program.get().selected_sequencer_pattern).channels[x]
 end
 
 function program.set(p)

--- a/lib/program.lua
+++ b/lib/program.lua
@@ -209,6 +209,14 @@ function program.set_global_step_scale_number(step_scale_number)
 
 end
 
+function program.set_channel_step_scale_number(c, step_scale_number)
+
+  for _, sequencer_pattern in pairs(program_store.sequencer_patterns) do
+    sequencer_pattern.channels[c].step_scale_number = step_scale_number
+  end
+
+end
+
 function program.get()
   return program_store
 end

--- a/lib/step_handler.lua
+++ b/lib/step_handler.lua
@@ -138,7 +138,6 @@ function step_handler.calculate_step_scale_number(c, current_step)
   
   if program.get_current_step_for_channel(17) == 1 then
     persistent_global_step_scale_number = nil
-    
   end
 
   -- Scale Precedence : channel_step_scale > global_step_scale > channel_default_scale > global_default_scale
@@ -254,8 +253,7 @@ end
 
 function step_handler.process_global_step_scale_trig_lock(current_step)
 
-  program.get_channel(17).step_scale_number = step_handler.calculate_step_scale_number(17, current_step)
-  
+  program.set_global_step_scale_number(step_handler.calculate_step_scale_number(17, current_step))
 end
 
 

--- a/lib/step_handler.lua
+++ b/lib/step_handler.lua
@@ -35,6 +35,7 @@ end
 
 
 function step_handler.process_params(c, step)
+
   local channel = program.get_channel(c)
   local device = device_map.get_device(program.get().devices[channel.number].device_map)
 
@@ -121,16 +122,23 @@ function step_handler.calculate_step_scale_number(c, current_step)
 
   local channel = program.get_channel(c)
   local channel_step_scale_number = program.get_step_scale_trig_lock(channel, current_step)
-  local global_step_scale_number = program.get_step_scale_trig_lock(program.get_channel(17), program.get().current_step)
+
+  if c == 17 then
+    channel_step_scale_number = nil
+    persistent_channel_step_scale_numbers[17] = nil
+  end
+
+  local global_step_scale_number = program.get_step_scale_trig_lock(program.get_channel(17), program.get_current_step_for_channel(17))
   local channel_default_scale = channel.default_scale
   local global_default_scale = program.get().default_scale
 
   if current_step == 1 then
     persistent_channel_step_scale_numbers[c] = nil
   end
-
-  if program.get().current_step == 1 then
+  
+  if program.get_current_step_for_channel(17) == 1 then
     persistent_global_step_scale_number = nil
+    
   end
 
   -- Scale Precedence : channel_step_scale > global_step_scale > channel_default_scale > global_default_scale
@@ -246,7 +254,8 @@ end
 
 function step_handler.process_global_step_scale_trig_lock(current_step)
 
-  program.get_channel(17).step_scale_number = persistent_global_step_scale_number or program.get_step_scale_trig_lock(program.get_channel(17), current_step)
+  program.get_channel(17).step_scale_number = step_handler.calculate_step_scale_number(17, current_step)
+  
 end
 
 
@@ -365,7 +374,7 @@ function step_handler.reset()
 end
 
 function step_handler.reset_sequencer_pattern() 
-  for i = 1, 16 do
+  for i = 1, 17 do
     program.set_current_step_for_channel(i, 1)
   end
 end

--- a/mosaic.lua
+++ b/mosaic.lua
@@ -1,4 +1,4 @@
--- mosaic v0.3
+-- mosaic v0.3.1
 -- grid-centric, intentioned 
 -- generative sequencer.
 --


### PR DESCRIPTION
# 0.3.1

_Breaking update. Please backup and remove your .pset and .ptn data files from previous versions._

* It's now possible to set a clock division or multiplication for global scale, enabling slower or faster scale progressions and progressions that apply using sequences of less than 64 steps.
* Midi clock sync logic has been improved
* Clock logic has been entirely rewritten and is much more stable
* Various clock and sequencer bug fixes
